### PR TITLE
Call FFC directly from CMake

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,8 @@ jobs:
           name: Install DOLFIN (C++)
           command: |
             git clone --depth=1 https://github.com/FEniCS/dolfinx.git
-            mkdir build
-            cd build
-            cmake -G Ninja ../dolfinx/cpp
+            cd $(mktemp -d)
+            cmake -G Ninja $OLDPWD/dolfinx/cpp
             ninja -j3 install
       # - run:
       #     name: Install DOLFIN (Python interface)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,13 +28,14 @@ jobs:
       - run:
           name: Build test program
           command: |
-            cd src/
-            cmake -G Ninja .
+            mkdir build
+            cd build
+            cmake -G Ninja ../src
             ninja
       - run:
           name: Run Poisson test (BoomerAMG, weak)
           command: |
-            cd src/
+            cd build/
             mpirun -np 3 ./dolfin-scaling-test \
             --problem_type poisson \
             --scaling_type weak \
@@ -49,7 +50,7 @@ jobs:
       - run:
           name: Run Poisson test (BoomerAMG, weak, unstructured mesh)
           command: |
-            cd src/
+            cd build/
             mpirun -np 3 ./dolfin-scaling-test \
             --problem_type poisson \
             --mesh_type unstructured \
@@ -65,7 +66,7 @@ jobs:
       - run:
           name: Run Poisson test (BoomerAMG, strong)
           command: |
-            cd src/
+            cd build/
             mpirun -np 3 ./dolfin-scaling-test \
             --problem_type poisson \
             --scaling_type strong \
@@ -80,7 +81,7 @@ jobs:
       - run:
           name: Run elasticity test (GAMG, weak)
           command: |
-            cd src/
+            cd build/
             mpirun -np 3 ./dolfin-scaling-test \
             --problem_type elasticity \
             --scaling_type weak \
@@ -98,7 +99,7 @@ jobs:
       - run:
           name: Run elasticity test (GAMG, strong)
           command: |
-            cd src/
+            cd build/
             mpirun -np 3 ./dolfin-scaling-test \
             --problem_type elasticity \
             --scaling_type strong \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,12 +26,6 @@ jobs:
       #       cd dolfinx/python
       #       pip3 install .
       - run:
-          name: Compile UFL files
-          command: |
-            cd src/
-            ffc Elasticity.ufl
-            ffc Poisson.ufl
-      - run:
           name: Build test program
           command: |
             cd src/

--- a/README.md
+++ b/README.md
@@ -24,13 +24,7 @@ that are necessary to run the tests successfully, and for performance.
 
 ### Compilation
 
-In the `src/` directory:
-
-1. Compile the UFL files using FFC:
-
-        ffc *.ufl
-
-2. Build the program:
+In the `src/` directory, build the program:
 
         cmake .
         make

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,12 +17,12 @@ find_package(Boost COMPONENTS program_options REQUIRED)
 # Compile UFL files
 add_custom_command(
   OUTPUT Elasticity.c
-  COMMAND ffc Elasticity.ufl
+  COMMAND ffc ${CMAKE_CURRENT_SOURCE_DIR}/Elasticity.ufl
   DEPENDS Elasticity.ufl
 )
 add_custom_command(
   OUTPUT Poisson.c
-  COMMAND ffc Poisson.ufl
+  COMMAND ffc ${CMAKE_CURRENT_SOURCE_DIR}/Poisson.ufl
   DEPENDS Poisson.ufl
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,8 +14,22 @@ set(CMAKE_BUILD_TYPE "Release")
 
 find_package(Boost COMPONENTS program_options REQUIRED)
 
+# Compile UFL files
+add_custom_command(
+  OUTPUT Elasticity.c
+  COMMAND ffc Elasticity.ufl
+  DEPENDS Elasticity.ufl
+)
+add_custom_command(
+  OUTPUT Poisson.c
+  COMMAND ffc Poisson.ufl
+  DEPENDS Poisson.ufl
+)
+
 # Executable
-add_executable(${PROJECT_NAME} main.cpp mesh.cpp Elasticity.c Poisson.c)
+add_executable(${PROJECT_NAME} main.cpp mesh.cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/Elasticity.c
+  ${CMAKE_CURRENT_BINARY_DIR}/Poisson.c)
 
 # Target libraries
 target_link_libraries(${PROJECT_NAME} dolfin ${Boost_PROGRAM_OPTIONS_LIBRARY})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,7 @@ add_custom_command(
   COMMAND ffc ${CMAKE_CURRENT_SOURCE_DIR}/Poisson.ufl
   DEPENDS Poisson.ufl
 )
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 # Executable
 add_executable(${PROJECT_NAME} main.cpp mesh.cpp


### PR DESCRIPTION
Makes CMake responsible for calling ffc on the ufl files. Makes out-of-source builds possible and also adds the ufl files to CMake's dependency tracking. 