### PR TITLE
Fix MPI initialisation and finalisation and remove hard-wired compiler flags

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -37,7 +37,7 @@ jobs:
           git clone -b master --single-branch https://github.com/FEniCS/dolfinx.git
           cd $(mktemp -d)
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Release $OLDPWD/dolfinx/cpp
-          ninja -j3 install
+          ninja install
       - name: Build performance test
         env:
           PETSC_DIR: /usr/local/petsc-64
@@ -65,7 +65,7 @@ jobs:
       - name: Run Poisson test (BoomerAMG, weak)
         run: |
           cd build/
-          mpirun -np 3 ./dolfinx-scaling-test \
+          mpirun -np 2 ./dolfinx-scaling-test \
           --problem_type poisson \
           --scaling_type weak \
           --ndofs 50000 \
@@ -79,7 +79,7 @@ jobs:
       - name: Run Poisson test (BoomerAMG, weak, unstructured mesh)
         run: |
           cd build/
-          mpirun -np 3 ./dolfinx-scaling-test \
+          mpirun -np 2 ./dolfinx-scaling-test \
           --problem_type poisson \
           --mesh_type unstructured \
           --scaling_type weak \
@@ -94,7 +94,7 @@ jobs:
       - name: Run Poisson test (BoomerAMG, strong)
         run: |
           cd build/
-          mpirun -np 3 ./dolfinx-scaling-test \
+          mpirun -np 2 ./dolfinx-scaling-test \
           --problem_type poisson \
           --scaling_type strong \
           --ndofs 1000000 \
@@ -125,7 +125,7 @@ jobs:
       - name: Run elasticity test (GAMG, weak)
         run: |
           cd build/
-          mpirun -np 3 ./dolfinx-scaling-test \
+          mpirun -np 2 ./dolfinx-scaling-test \
           --problem_type elasticity \
           --scaling_type weak \
           --ndofs 100000 \
@@ -142,7 +142,7 @@ jobs:
       - name: Run elasticity test (GAMG, strong)
         run: |
           cd build/
-          mpirun -np 3 ./dolfinx-scaling-test \
+          mpirun -np 2 ./dolfinx-scaling-test \
           --problem_type elasticity \
           --scaling_type strong \
           --ndofs 500000 \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,8 +44,12 @@ find_package(Boost 1.70 REQUIRED program_options)
 target_link_libraries(${PROJECT_NAME} dolfinx Boost::program_options)
 
 # target_link_libraries(${PROJECT_NAME} stdc++fs)
-set_source_files_properties(main.cpp PROPERTIES COMPILE_FLAGS "-march=native -Wall -Wextra -pedantic -Werror -Ofast")
-set_source_files_properties(Poisson.c PROPERTIES COMPILE_FLAGS "-march=native -Ofast")
-set_source_files_properties(Elasticity.c PROPERTIES COMPILE_FLAGS "-march=native -Ofast")
+# set_source_files_properties(main.cpp PROPERTIES COMPILE_FLAGS "-march=native -Wall -Wextra -pedantic -Werror -Ofast")
+# set_source_files_properties(Poisson.c PROPERTIES COMPILE_FLAGS "-march=native -Ofast")
+# set_source_files_properties(Elasticity.c PROPERTIES COMPILE_FLAGS "-march=native -Ofast")
+
+set_source_files_properties(main.cpp PROPERTIES COMPILE_FLAGS "-Wall -Wextra -pedantic -Werror -Ofast")
+set_source_files_properties(Poisson.c PROPERTIES COMPILE_FLAGS "-Ofast")
+set_source_files_properties(Elasticity.c PROPERTIES COMPILE_FLAGS "-Ofast")
 
 install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -185,5 +185,7 @@ int main(int argc, char* argv[])
     std::cout << "*** Solution norm:  " << norm << std::endl;
   }
 
+  dolfinx::common::SubSystemsManager::finalize_petsc();
+  dolfinx::common::SubSystemsManager::finalize_mpi();
   return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,12 +23,8 @@
 
 namespace po = boost::program_options;
 
-int main(int argc, char* argv[])
+void solve(int argc, char* argv[])
 {
-  dolfinx::common::SubSystemsManager::init_logging(argc, argv);
-  dolfinx::common::SubSystemsManager::init_mpi();
-  dolfinx::common::SubSystemsManager::init_petsc(argc, argv);
-
   po::options_description desc("Allowed options");
   desc.add_options()("help,h", "print usage message")(
       "problem_type", po::value<std::string>()->default_value("poisson"),
@@ -53,7 +49,7 @@ int main(int argc, char* argv[])
   if (vm.count("help"))
   {
     std::cout << desc << "\n";
-    return 0;
+    return;
   }
 
   const std::string problem_type = vm["problem_type"].as<std::string>();
@@ -184,6 +180,15 @@ int main(int argc, char* argv[])
     std::cout << "*** Number of Krylov iterations: " << num_iter << std::endl;
     std::cout << "*** Solution norm:  " << norm << std::endl;
   }
+}
+
+int main(int argc, char* argv[])
+{
+  dolfinx::common::SubSystemsManager::init_logging(argc, argv);
+  dolfinx::common::SubSystemsManager::init_mpi();
+  dolfinx::common::SubSystemsManager::init_petsc(argc, argv);
+
+  solve(argc, argv);
 
   dolfinx::common::SubSystemsManager::finalize_petsc();
   dolfinx::common::SubSystemsManager::finalize_mpi();


### PR DESCRIPTION
Hard-wired compiler flags caused segfaults due to alignment issues.