### PR TITLE
update mdspan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Performance test codes for FEniCS/DOLFIN-X
+# Performance test codes for FEniCSx/DOLFINx
 
 This repository contains solvers for testing the parallel performance of
-DOLFIN-X and the underlying linear solvers. It tests elliptic equations
+DOLFINx and the underlying linear solvers. It tests elliptic equations
 - Poisson equation and elasticity - in three dimensions.
 
 Representative performance data is available at
@@ -16,7 +16,7 @@ The source of the tests is in `src/` directory.
 
 ### Requirements
 
-- FEniCSx/DOLFINx installation (development version of dolfinx
+- FEniCSx/DOLFINx installation (development version of DOLFINx
   **required**)
 - PETSc installation
 - Boost Program Options

--- a/src/Elasticity.py
+++ b/src/Elasticity.py
@@ -4,8 +4,9 @@
 #
 # SPDX-License-Identifier:    MIT
 
-from ufl import (Coefficient, Identity, TestFunction, TrialFunction,
-                 VectorElement, dx, grad, inner, tetrahedron, tr)
+import basix.ufl
+from ufl import (Coefficient, Identity, FunctionSpace, Mesh, TestFunction, TrialFunction,
+                 dx, grad, inner, tetrahedron, tr)
 
 # Elasticity parameters
 E = 1.0e6
@@ -19,10 +20,12 @@ ns = vars()
 
 forms = []
 for degree in range(1, 4):
-    element = VectorElement("Lagrange", cell, degree)
+    element = basix.ufl.element("Lagrange", "tetrahedron", degree, shape=(3, ))
+    domain = Mesh(element)
+    space = FunctionSpace(domain, element)
 
-    u, v = TrialFunction(element), TestFunction(element)
-    f = Coefficient(element)
+    u, v = TrialFunction(space), TestFunction(space)
+    f = Coefficient(space)
 
     def eps(v):
         return 0.5*(grad(v) + grad(v).T)

--- a/src/Elasticity.py
+++ b/src/Elasticity.py
@@ -21,7 +21,7 @@ ns = vars()
 forms = []
 for degree in range(1, 4):
     element = basix.ufl.element("Lagrange", "tetrahedron", degree, shape=(3, ))
-    domain = Mesh(element)
+    domain = Mesh(basix.ufl.element("Lagrange", "tetrahedron", 1, shape=(3, )))
     space = FunctionSpace(domain, element)
 
     u, v = TrialFunction(space), TestFunction(space)

--- a/src/Poisson.py
+++ b/src/Poisson.py
@@ -4,7 +4,8 @@
 #
 # SPDX-License-Identifier:    MIT
 
-from ufl import (Coefficient, FiniteElement, TestFunction, TrialFunction, action, ds,
+import basix.ufl
+from ufl import (Coefficient, FunctionSpace, TestFunction, TrialFunction, Mesh, action, ds,
                  dx, grad, inner, tetrahedron)
 
 # Load namespace
@@ -12,13 +13,15 @@ ns = vars()
 
 forms = []
 for degree in range(1, 4):
-    element = FiniteElement("Lagrange", tetrahedron, degree)
+    element = basix.ufl.element("Lagrange", "tetrahedron", degree)
+    domain = Mesh(basix.ufl.element("Lagrange", "tetrahedron", degree, shape=(3,)))
+    space = FunctionSpace(domain, element)
 
-    u = TrialFunction(element)
-    v = TestFunction(element)
-    f = Coefficient(element)
-    g = Coefficient(element)
-    un = Coefficient(element)
+    u = TrialFunction(space)
+    v = TestFunction(space)
+    f = Coefficient(space)
+    g = Coefficient(space)
+    un = Coefficient(space)
 
     aname = 'a' + str(degree)
     Lname = 'L' + str(degree)

--- a/src/Poisson.py
+++ b/src/Poisson.py
@@ -14,7 +14,7 @@ ns = vars()
 forms = []
 for degree in range(1, 4):
     element = basix.ufl.element("Lagrange", "tetrahedron", degree)
-    domain = Mesh(basix.ufl.element("Lagrange", "tetrahedron", degree, shape=(3,)))
+    domain = Mesh(basix.ufl.element("Lagrange", "tetrahedron", 1, shape=(3,)))
     space = FunctionSpace(domain, element)
 
     u = TrialFunction(space)

--- a/src/elasticity_problem.cpp
+++ b/src/elasticity_problem.cpp
@@ -6,6 +6,7 @@
 
 #include "elasticity_problem.h"
 #include "Elasticity.h"
+#include <basix/mdspan.hpp>
 #include <dolfinx/common/Timer.h>
 #include <dolfinx/fem/DirichletBC.h>
 #include <dolfinx/fem/DofMap.h>
@@ -70,8 +71,11 @@ MatNullSpace build_near_nullspace(const fem::FunctionSpace<double>& V)
   }
 
   // Orthonormalize basis
-  la::orthonormalize(std::vector<std::reference_wrapper<la::Vector<T>>>(basis.begin(), basis.end()));
-  if (!la::is_orthonormal(std::vector<std::reference_wrapper<const la::Vector<T>>>(basis.begin(), basis.end())))
+  la::orthonormalize(std::vector<std::reference_wrapper<la::Vector<T>>>(
+      basis.begin(), basis.end()));
+  if (!la::is_orthonormal(
+          std::vector<std::reference_wrapper<const la::Vector<T>>>(
+              basis.begin(), basis.end())))
   {
     throw std::runtime_error("Space not orthonormal");
   }
@@ -145,9 +149,12 @@ elastic::problem(std::shared_ptr<mesh::Mesh<double>> mesh, int order)
       [](auto x) -> std::pair<std::vector<T>, std::vector<std::size_t>>
       {
         std::vector<T> vdata(x.extent(0) * x.extent(1));
-        namespace stdex = std::experimental;
-        stdex::mdspan<double,
-                      stdex::extents<std::size_t, 3, stdex::dynamic_extent>>
+        namespace stdex
+            = MDSPAN_IMPL_STANDARD_NAMESPACE::MDSPAN_IMPL_PROPOSED_NAMESPACE;
+        MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
+            T,
+            MDSPAN_IMPL_STANDARD_NAMESPACE::extents<
+                std::size_t, 3, MDSPAN_IMPL_STANDARD_NAMESPACE::dynamic_extent>>
             v(vdata.data(), x.extent(0), x.extent(1));
         for (std::size_t p = 0; p < x.extent(1); ++p)
         {


### PR DESCRIPTION
Using [this](https://github.com/FEniCS/basix/pull/699/files) as a guide: 
Performance-test (even the poisson example) still fails with:
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  UFL mesh and CoordinateElement do not match.
```
  
  ^ is fixed by #143 