### PR TITLE
Bring dolfinx::refinement::refine up to date with dolfinx 0.9.0

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -33,16 +33,16 @@ jobs:
         with:
           path: ./dolfinx
           repository: FEniCS/dolfinx
-          ref: main
+          ref: v0.9.0
 
       - name: Install FEniCS Python components
         run: |
           apt-get -qq update
           apt-get -y install libboost-program-options-dev
           pip3 install --break-system-packages pip --upgrade
-          pip3 install --break-system-packages git+https://github.com/FEniCS/ufl.git
-          pip3 install --break-system-packages git+https://github.com/FEniCS/basix.git
-          pip3 install --break-system-packages git+https://github.com/FEniCS/ffcx
+          pip3 install --break-system-packages git+https://github.com/FEniCS/ufl.git@2024.2.0
+          pip3 install --break-system-packages git+https://github.com/FEniCS/basix.git@v0.9.0
+          pip3 install --break-system-packages git+https://github.com/FEniCS/ffcx@v0.9.0
       - name: Build dolfinx cpp
         run: |
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build -S dolfinx/cpp/

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,0 +1,9 @@
+CMakeCache.txt
+CMakeFiles/
+Elasticity.c
+Elasticity.h
+Makefile
+Poisson.c
+Poisson.h
+cmake_install.cmake
+dolfinx-scaling-test

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -192,7 +192,10 @@ create_cube_mesh(MPI_Comm comm, std::size_t target_dofs, bool target_dofs_total,
   for (int i = 0; i < r; ++i)
   {
     mesh.topology_mutable()->create_connectivity(3, 1);
-    auto [new_mesh, _x, _y] = dolfinx::refinement::refine(mesh, std::nullopt, false);
+    auto [new_mesh, _parent_edges, _parent_facet] = dolfinx::refinement::refine(
+      mesh, std::nullopt,
+      dolfinx::mesh::create_cell_partitioner(dolfinx::mesh::GhostMode::shared_facet),
+      dolfinx::refinement::Option::parent_cell_and_facet);
     mesh = std::move(new_mesh);
   }
 
@@ -366,7 +369,10 @@ create_spoke_mesh(MPI_Comm comm, std::size_t target_dofs,
              + mesh->topology()->index_map(1)->size_global()
          < target)
   {
-    auto [new_mesh, _x, _y] = dolfinx::refinement::refine(*mesh, std::nullopt, false);
+    auto [new_mesh, _parent_edges, _parent_facet] = dolfinx::refinement::refine(
+      *mesh, std::nullopt,
+      dolfinx::mesh::create_cell_partitioner(dolfinx::mesh::GhostMode::shared_facet),
+      dolfinx::refinement::Option::parent_cell_and_facet);
     mesh = std::make_shared<dolfinx::mesh::Mesh<double>>(new_mesh);
     mesh->topology_mutable()->create_entities(1);
   }
@@ -401,7 +407,10 @@ create_spoke_mesh(MPI_Comm comm, std::size_t target_dofs,
       if (i % 2000 < nmarked)
         marked_edges.push_back(i);
 
-    auto [new_mesh, _x, _y] = dolfinx::refinement::refine(*mesh, marked_edges, false);
+    auto [new_mesh, _parent_edges, _parent_facet] = dolfinx::refinement::refine(
+      *mesh, marked_edges,
+      dolfinx::mesh::create_cell_partitioner(dolfinx::mesh::GhostMode::shared_facet),
+      dolfinx::refinement::Option::parent_cell_and_facet);
     meshi = std::make_shared<dolfinx::mesh::Mesh<double>>(new_mesh);
 
     double actual_fraction


### PR DESCRIPTION
Due to changes in
https://github.com/FEniCS/dolfinx/pull/3322
https://github.com/FEniCS/dolfinx/pull/3444

Also temporarily pins versions in CI workflow for release 0.9.0. Will undo immediately as soon as the merge queue is empty.