### PR TITLE
Bring `dolfinx::list_timings` signature up to date with current `dolfinx` main branch

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -33,16 +33,16 @@ jobs:
         with:
           path: ./dolfinx
           repository: FEniCS/dolfinx
-          ref: v0.9.0
+          ref: main
 
       - name: Install FEniCS Python components
         run: |
           apt-get -qq update
           apt-get -y install libboost-program-options-dev
           pip3 install --break-system-packages pip --upgrade
-          pip3 install --break-system-packages git+https://github.com/FEniCS/ufl.git@2024.2.0
-          pip3 install --break-system-packages git+https://github.com/FEniCS/basix.git@v0.9.0
-          pip3 install --break-system-packages git+https://github.com/FEniCS/ffcx@v0.9.0
+          pip3 install --break-system-packages git+https://github.com/FEniCS/ufl.git
+          pip3 install --break-system-packages git+https://github.com/FEniCS/basix.git
+          pip3 install --break-system-packages git+https://github.com/FEniCS/ffcx
       - name: Build dolfinx cpp
         run: |
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build -S dolfinx/cpp/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -219,7 +219,7 @@ void solve(int argc, char* argv[])
   }
 
   // Display timings
-  dolfinx::list_timings(MPI_COMM_WORLD, {dolfinx::TimingType::wall});
+  dolfinx::list_timings(MPI_COMM_WORLD);
 
   // Report number of Krylov iterations
   double norm = dolfinx::la::norm(*(u->x()));


### PR DESCRIPTION
Due to upstream changes in https://github.com/FEniCS/dolfinx/pull/3484

Also reverts the temporary change to CI introduced in #160: unpin release 0.9.0 and go back to testing `dolfinx` main