### PR TITLE
Output performance of CPU code in Gdof/s processed when using action kernel 

### DIFF
--- a/src/cgpoisson_problem.cpp
+++ b/src/cgpoisson_problem.cpp
@@ -242,8 +242,7 @@ cgpoisson::problem(std::shared_ptr<mesh::Mesh<double>> mesh, int order,
         = static_cast<double>(V->dofmap()->index_map->size_global());
     double gdofs = (num_it * ndofs_global) / time / 1e9;
 
-    std::cout << "Processed " << gdofs << " Gdofs/s\n";
-    std::cout << "dofs=" << ndofs_global << " time = " << time << "\n";
+    std::cout << "CG matrix-free action processed: " << gdofs << " Gdof/s\n";
 
     return num_it;
   };

--- a/src/cgpoisson_problem.cpp
+++ b/src/cgpoisson_problem.cpp
@@ -233,7 +233,18 @@ cgpoisson::problem(std::shared_ptr<mesh::Mesh<double>> mesh, int order,
       sct.scatter_fwd_end<T>(remote_buffer, remote_data, unpack_fn, request);
     };
 
+    common::Timer tcg;
     int num_it = linalg::cg(*u.x(), b, action, 100, 1e-6);
+    tcg.stop();
+    tcg.flush();
+    double time = std::chrono::duration<double>(tcg.elapsed()).count();
+    double ndofs_global
+        = static_cast<double>(V->dofmap()->index_map->size_global());
+    double gdofs = (num_it * ndofs_global) / time / 1e9;
+
+    std::cout << "Processed " << gdofs << " Gdofs/s\n";
+    std::cout << "dofs=" << ndofs_global << " time = " << time << "\n";
+
     return num_it;
   };
 


### PR DESCRIPTION
Adds an output of Gdof/s when using the `--problem=cgpoisson` example